### PR TITLE
Fix code scanning alert no. 83: Request without certificate validation

### DIFF
--- a/simple_vm_client/metadata_connector/metadata_connector.py
+++ b/simple_vm_client/metadata_connector/metadata_connector.py
@@ -75,8 +75,7 @@ class MetadataConnector:
                 timeout=(30, 30),
                 headers={
                     "X-Auth-Token": self.METADATA_SERVER_TOKEN,
-                },
-                verify=False,
+                }
             )
             response.raise_for_status()
             logger.info(f"Metadata removed successfully for {ip}")
@@ -105,8 +104,7 @@ class MetadataConnector:
                 headers={
                     "X-Auth-Token": self.METADATA_SERVER_TOKEN,
                     "Content-Type": "application/json",
-                },
-                verify=False,
+                }
             )
             response.raise_for_status()
             logger.info(f"Metadata set successfully for {ip}")
@@ -125,8 +123,7 @@ class MetadataConnector:
         try:
             response = requests.get(
                 health_url,
-                timeout=(30, 30),
-                verify=False,
+                timeout=(30, 30)
             )
             response.raise_for_status()
             logger.info(f"Metadata Health Check --- {response.json()}")


### PR DESCRIPTION
Fixes [https://github.com/deNBI/simplevm-client/security/code-scanning/83](https://github.com/deNBI/simplevm-client/security/code-scanning/83)

To fix the problem, we need to ensure that SSL certificate verification is enabled for all HTTP requests. This can be done by removing the `verify=False` parameter or setting it to `True`. If a custom certificate is required, the path to the certificate should be provided.

1. Remove the `verify=False` parameter from the `requests.get`, `requests.post`, and `requests.delete` calls.
2. If necessary, add a parameter to the class to accept a custom certificate path and use it in the `verify` parameter.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
