### PR TITLE
Fix code scanning alert no. 81: Request without certificate validation

### DIFF
--- a/simple_vm_client/metadata_connector/metadata_connector.py
+++ b/simple_vm_client/metadata_connector/metadata_connector.py
@@ -75,8 +75,7 @@ class MetadataConnector:
                 timeout=(30, 30),
                 headers={
                     "X-Auth-Token": self.METADATA_SERVER_TOKEN,
-                },
-                verify=False,
+                }
             )
             response.raise_for_status()
             logger.info(f"Metadata removed successfully for {ip}")
@@ -125,8 +124,7 @@ class MetadataConnector:
         try:
             response = requests.get(
                 health_url,
-                timeout=(30, 30),
-                verify=False,
+                timeout=(30, 30)
             )
             response.raise_for_status()
             logger.info(f"Metadata Health Check --- {response.json()}")


### PR DESCRIPTION
Fixes [https://github.com/deNBI/simplevm-client/security/code-scanning/81](https://github.com/deNBI/simplevm-client/security/code-scanning/81)

To fix the problem, we need to ensure that SSL certificate verification is enabled for all requests. This can be done by removing the `verify=False` parameter or setting it to `True`. If the application uses self-signed certificates, we should provide the path to the certificate file instead of disabling verification.

1. **Remove `verify=False`**: This will make the requests use the default behavior, which is to verify SSL certificates.
2. **Provide a certificate file**: If the server uses a self-signed certificate, we should specify the path to the certificate file using the `verify` parameter.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
