### PR TITLE
fix(OpenStack):setting compute api version via config

### DIFF
--- a/simple_vm_client/config/config.yml
+++ b/simple_vm_client/config/config.yml
@@ -53,6 +53,8 @@ openstack:
   #IP address of the OpenStack gateway.
   network: portalexternalnetwork
   # Name or identifier of the openstack network
+  compute_api_version: 2.96
+  # nova api version
 
 # Bibigrid configuration
 bibigrid:

--- a/simple_vm_client/config/config_local.yml
+++ b/simple_vm_client/config/config_local.yml
@@ -53,6 +53,8 @@ openstack:
   # IP address of the OpenStack gateway.
   network: portalexternalnetwork
   # Name or identifier of the openstack network
+  compute_api_version: 2.96
+  # nova api version
 
 # Bibigrid configuration
 bibigrid:

--- a/simple_vm_client/openstack_connector/openstack_connector.py
+++ b/simple_vm_client/openstack_connector/openstack_connector.py
@@ -182,7 +182,7 @@ class OpenStackConnector:
             if "compute_api_version" in cfg["openstack"]:
                 self.NOVA_MICROVERSION = cfg["openstack"]["compute_api_version"]
                 logger.debug(
-                    "Using custom compute API version",
+                    "Using compute API version",
                     extra={"api_version": self.NOVA_MICROVERSION},
                 )
 
@@ -194,6 +194,7 @@ class OpenStackConnector:
                     "gateway_ip": self.GATEWAY_IP,
                     "production": self.PRODUCTION,
                     "threads": self.THREADS,
+                    "compute_api_version": self.NOVA_MICROVERSION,
                 },
             )
 

--- a/simple_vm_client/openstack_connector/test_openstack_connector.py
+++ b/simple_vm_client/openstack_connector/test_openstack_connector.py
@@ -183,6 +183,7 @@ class TestOpenStackConnector(unittest.TestCase):
             self.openstack_connector.GATEWAY_SECURITY_GROUP_ID = (
                 "dedasdasdasdadew1231231"
             )
+            self.openstack_connector.NOVA_MICROVERSION = "2.1"
             with tempfile.NamedTemporaryFile(mode="w+", delete=False) as temp_file:
                 temp_file.write(CONFIG_DATA)
 
@@ -196,6 +197,7 @@ class TestOpenStackConnector(unittest.TestCase):
             openstack_connector = OpenStackConnector(None, None)
             openstack_connector.openstack_connection = self.mock_openstack_connection
             openstack_connector.DEFAULT_SECURITY_GROUPS = DEFAULT_SECURITY_GROUPS
+            openstack_connector.NOVA_MICROVERSION = "2.1"
 
         return openstack_connector
 


### PR DESCRIPTION
Provide compuite API version via config

https://github.com/deNBI/simplevm-client/issues/974

Also the Branch https://github.com/deNBI/simplevm-portal/tree/feat/compute_api_version should be merged but currently github shows an eror when trying to create a PR

Try to fulfill the following points before the Pull Request is merged:

- [ ] Give a meaningfull description for the PR
- [ ] The PR is reviewed by one of the team members.
- [ ] If a linting PR exists, it must be merged before this PR is allowed to be merged.
- [ ] It must be checked if anything in the Readme must be adjusted (development-, production-, setup).
- [ ] If the requirements.txt have changed, check if the patches still work
- [ ] It must be checked if any section in the wiki (https://simplevm.denbi.de/wiki/) should be adjusted.
- [ ] If the PR is merged in the master then a release should be be made.
- [ ] If the new code is readable, if not it should be well commented


**For any changes of the code please consider:**
- [ ] Cover the changes with corresponding unit tests 

For releases only:

- [ ] If the review of this PR is approved and the PR is followed by a release then the .env file
  in the cloud-portal repo should also be updated.
- [ ] If you are making a release then please sum up the changes since the last release on the release page using the [clog](https://github.com/clog-tool/clog-cli) tool with `clog -F`

