### PR TITLE
Feat/generate own keypair

### DIFF
--- a/simple_vm_client/forc_connector/forc_connector.py
+++ b/simple_vm_client/forc_connector/forc_connector.py
@@ -553,6 +553,7 @@ class ForcConnector:
                 logger.info(ForcConnector.active_playbooks)
                 playbook = ForcConnector.active_playbooks[openstack_id]
                 playbook.check_status(openstack_id)
+
             status = self.redis_connection.hget(openstack_id, "status").decode("utf-8")
             logger.info(f"VM {openstack_id} Playbook status -> {status}")
 

--- a/simple_vm_client/forc_connector/forc_connector.py
+++ b/simple_vm_client/forc_connector/forc_connector.py
@@ -30,6 +30,7 @@ BIOCONDA = "bioconda"
 
 class ForcConnector:
     active_playbooks: dict[str, Playbook] = {}
+    TOTAL_TIMEOUT = 30 * 60  # 30 minutes
 
     def __init__(self, config_file: str):
         logger.info("Initializing Forc Connector")
@@ -323,7 +324,7 @@ class ForcConnector:
                 location_url=data["location_url"],
                 template=data["template"],
                 template_version=data["template_version"],
-                auth_enabled=data.get("auth_enabled",True),
+                auth_enabled=data.get("auth_enabled", True),
             )
             return new_backend
 
@@ -485,6 +486,30 @@ class ForcConnector:
             playbook = ForcConnector.active_playbooks[openstack_id]
             status, stdout, stderr = playbook.get_logs()
             logger.warning(f" Playbook logs {openstack_id} status: {status}")
+
+            # Check total timeout
+            playbook_start = self.redis_connection.hget(
+                openstack_id, "playbook_start_time"
+            )
+            if playbook_start is None:
+                # First check — store start time
+                self.redis_connection.hset(
+                    openstack_id, "playbook_start_time", str(time.time())
+                )
+            else:
+                elapsed = time.time() - float(playbook_start)
+                if elapsed > self.TOTAL_TIMEOUT:
+                    logger.error(
+                        f"Playbook for (openstack_id) {openstack_id} exceeded total timeout "
+                        f"({elapsed:.0f}s > {self.TOTAL_TIMEOUT}s). Failing."
+                    )
+                    playbook.stop(openstack_id)
+                    self.redis_connection.hset(
+                        openstack_id, "status", VmTaskStates.PLAYBOOK_FAILED.value
+                    )
+                    ForcConnector.active_playbooks.pop(openstack_id)
+                    return PlaybookResult(status=-1, stdout="", stderr="")
+
             vm_status = self.redis_connection.hget(openstack_id, "status").decode(
                 "utf-8"
             )

--- a/simple_vm_client/forc_connector/playbook/playbook.py
+++ b/simple_vm_client/forc_connector/playbook/playbook.py
@@ -89,7 +89,7 @@ class Playbook(object):
         self.inventory.close()
 
         # Timeout tracking
-        self.IDLE_TIMEOUT = 10 * 60  # 10 minutes
+        self.IDLE_TIMEOUT = 20 * 60  # 15 minutes
         self._start_time = None
         self._last_log_size_stdout = 0
         self._last_log_size_stderr = 0

--- a/simple_vm_client/forc_connector/playbook/playbook.py
+++ b/simple_vm_client/forc_connector/playbook/playbook.py
@@ -2,6 +2,7 @@ import os
 import shlex
 import shutil
 import subprocess
+import time
 from tempfile import NamedTemporaryFile, TemporaryDirectory
 
 import redis
@@ -86,6 +87,12 @@ class Playbook(object):
         )
         self.inventory.write(inventory_string)
         self.inventory.close()
+
+        # Timeout tracking
+        self.IDLE_TIMEOUT = 10 * 60  # 10 minutes
+        self._start_time = None
+        self._last_log_size_stdout = 0
+        self._last_log_size_stderr = 0
 
     def copy_and_init_change_keys(self, public_key) -> None:
         shutil.copy(
@@ -312,6 +319,9 @@ class Playbook(object):
         )
 
     def run_it(self) -> None:
+        self._start_time = time.time()
+        self._last_log_size_stdout = 0
+        self._last_log_size_stderr = 0
         command_string = f"/usr/local/bin/ansible-playbook -v -i {self.inventory.name} {self.directory.name}/{self.playbook_exec_name}"
         command_string = shlex.split(command_string)  # type: ignore
         logger.info(f"Run Playbook for {self.playbook_exec_name} - [{command_string}]")
@@ -324,13 +334,51 @@ class Playbook(object):
 
     def check_status(self, openstack_id: str) -> int:
         logger.info(f"Check Status Playbook for VM {openstack_id}")
+
+        # Check idle timeout before process poll
         done = self.process.poll()
         logger.info(f"Status Playbook for VM {openstack_id}: {done}")
 
         if done is None:
-            logger.info(
-                f"Playbook for (openstack_id) {openstack_id} still in progress."
-            )
+            # Process still running — check for idle (no log growth)
+            if self._start_time is not None:
+                elapsed = time.time() - self._start_time
+                try:
+                    current_stdout_size = os.path.getsize(self.log_file_stdout.name)
+                    current_stderr_size = os.path.getsize(self.log_file_stderr.name)
+                except OSError:
+                    current_stdout_size = 0
+                    current_stderr_size = 0
+
+                if (
+                    current_stdout_size == self._last_log_size_stdout
+                    and current_stderr_size == self._last_log_size_stderr
+                ):
+                    # No log growth
+                    if elapsed > self.IDLE_TIMEOUT:
+                        logger.warning(
+                            f"Playbook for (openstack_id) {openstack_id} is stuck "
+                            f"(idle for {elapsed:.0f}s > {self.IDLE_TIMEOUT}s). Terminating."
+                        )
+                        self.process.terminate()
+                        self.returncode = self.process.returncode
+                        self.process.wait()
+                        self.redis.hset(
+                            openstack_id, "status", VmTaskStates.PLAYBOOK_FAILED.value
+                        )
+                        return -1
+                else:
+                    # Logs grew — update tracked sizes
+                    self._last_log_size_stdout = current_stdout_size
+                    self._last_log_size_stderr = current_stderr_size
+                    logger.info(
+                        f"Playbook for (openstack_id) {openstack_id} still in progress "
+                        f"(elapsed: {elapsed:.0f}s)."
+                    )
+            else:
+                logger.info(
+                    f"Playbook for (openstack_id) {openstack_id} still in progress."
+                )
             return 3
         elif done != 0:
             logger.info(f"Playbook for (openstack_id) {openstack_id} has failed.")

--- a/simple_vm_client/forc_connector/playbook/test_playbook.py
+++ b/simple_vm_client/forc_connector/playbook/test_playbook.py
@@ -1,4 +1,5 @@
 import os
+import time
 import unittest
 from tempfile import TemporaryDirectory
 from unittest.mock import MagicMock, patch
@@ -42,6 +43,14 @@ class TestPlaybook(unittest.TestCase):
             playbook.research_environment_template = None
             playbook.cloud_site = DEFAULT_CLOUD_SITE
             playbook.playbook_exec_name: str = "generic_playbook.yml"
+            playbook._start_time = None
+            playbook._last_log_size_stdout = 0
+            playbook._last_log_size_stderr = 0
+            playbook.IDLE_TIMEOUT = 60 * 60
+            playbook.log_file_stdout = MagicMock()
+            playbook.log_file_stdout.name = "/tmp/log_stdout"
+            playbook.log_file_stderr = MagicMock()
+            playbook.log_file_stderr.name = "/tmp/log_stderr"
 
             playbook.directory = TemporaryDirectory(dir=f"{playbook.playbooks_dir}")
         return playbook
@@ -146,6 +155,7 @@ class TestPlaybook(unittest.TestCase):
         openstack_id = "your_openstack_id"
 
         instance = self.init_playbook()
+        instance._start_time = None  # Not set yet (run_it not called)
 
         mock_process = MagicMock()
         mock_process.poll.return_value = None
@@ -220,6 +230,57 @@ class TestPlaybook(unittest.TestCase):
             f"Playbook for (openstack_id) {openstack_id} is successful."
         )
         self.assertEqual(result, 0)
+
+    @patch("simple_vm_client.forc_connector.playbook.playbook.os.path.getsize")
+    def test_check_status_idle_timeout(self, mock_getsize):
+        # Arrange
+        openstack_id = "your_openstack_id"
+
+        instance = self.init_playbook()
+        instance._start_time = time.time() - 7200  # 2 hours ago
+        instance._last_log_size_stdout = 0
+        instance._last_log_size_stderr = 0
+        instance.redis = MagicMock()
+
+        mock_process = MagicMock()
+        mock_process.poll.return_value = None
+        mock_process.returncode = -15
+        instance.process = mock_process
+        mock_getsize.side_effect = [0, 0]  # No log growth
+
+        # Act
+        result = instance.check_status(openstack_id)
+
+        # Assert
+        mock_process.terminate.assert_called_once()
+        instance.redis.hset.assert_called_once_with(
+            openstack_id, "status", VmTaskStates.PLAYBOOK_FAILED.value
+        )
+        self.assertEqual(result, -1)
+
+    @patch("os.path.getsize")
+    def test_check_status_not_idle(self, mock_getsize):
+        # Arrange
+        openstack_id = "your_openstack_id"
+
+        instance = self.init_playbook()
+        instance._start_time = time.time() - 7200  # 2 hours ago
+        instance._last_log_size_stdout = 0
+        instance._last_log_size_stderr = 0
+        instance.redis = MagicMock()
+
+        mock_process = MagicMock()
+        mock_process.poll.return_value = None
+        instance.process = mock_process
+        mock_getsize.side_effect = [100, 0]  # Log grew
+
+        # Act
+        result = instance.check_status(openstack_id)
+
+        # Assert
+        mock_process.terminate.assert_not_called()
+        instance.redis.hset.assert_not_called()
+        self.assertEqual(result, 3)
 
     @patch("simple_vm_client.forc_connector.playbook.playbook.logger")
     @patch("simple_vm_client.forc_connector.playbook.playbook.subprocess.Popen")

--- a/simple_vm_client/openstack_connector/openstack_connector.py
+++ b/simple_vm_client/openstack_connector/openstack_connector.py
@@ -13,6 +13,8 @@ from uuid import uuid4
 
 import sympy
 import yaml
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
 from keystoneauth1 import session
 from keystoneauth1.identity import v3
 from keystoneauth1.identity.v3 import application_credential
@@ -2597,6 +2599,26 @@ class OpenStackConnector:
         )
         return security_groups
 
+    def generate_keypair(self, bits: int = 4096) -> tuple[str, str]:
+        logger.debug("Generating local keypair", extra={"bits": bits})
+        private_key = rsa.generate_private_key(
+            public_exponent=65537,
+            key_size=bits,
+        )
+        private_key_pem = private_key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.OpenSSH,
+            encryption_algorithm=serialization.NoEncryption(),
+        ).decode("utf-8")
+
+        public_key = private_key.public_key()
+        public_key_openssh = public_key.public_bytes(
+            encoding=serialization.Encoding.OpenSSH,
+            format=serialization.PublicFormat.OpenSSH,
+        ).decode("utf-8")
+        logger.info("Keypair generated successfully", extra={"bits": bits})
+        return private_key_pem, public_key_openssh
+
     def start_server_with_playbook(
         self,
         flavor_name: str,
@@ -2638,12 +2660,11 @@ class OpenStackConnector:
             flavor: Flavor = self.get_flavor(name_or_id=flavor_name)
             network: Network = self.get_network()
 
+            private_key, public_key = self.generate_keypair(4096)
             key_creation: Keypair = self.openstack_connection.create_keypair(
-                name=servername
+                name=servername, public_key=public_key
             )
             key_name = key_creation.name
-
-            private_key = key_creation.private_key
 
             volumes = self._get_volumes_machines_start(
                 volume_ids_path_new=volume_ids_path_new,


### PR DESCRIPTION
@vktrrdk 

Since os_compute_version 0.94  openstack won't create a keypair without a public key, so we need to create a keypair our own.

Also added some more handling for stucked playbooks.

If the log does not updated for some minutes the playbook is stuck (or the ssh failed etc.) and the playbook will be set as failed.

Set in setting:    

  github_playbooks_repo: https://github.com/deNBI/resenvs/archive/refs/heads/feat/post_pre_refactor.zip



Try to fulfill the following points before the Pull Request is merged:

- [ ] Give a meaningfull description for the PR
- [ ] The PR is reviewed by one of the team members.
- [ ] If a linting PR exists, it must be merged before this PR is allowed to be merged.
- [ ] It must be checked if anything in the Readme must be adjusted (development-, production-, setup).
- [ ] If the requirements.txt have changed, check if the patches still work
- [ ] It must be checked if any section in the wiki (https://simplevm.denbi.de/wiki/) should be adjusted.
- [ ] If the PR is merged in the master then a release should be be made.
- [ ] If the new code is readable, if not it should be well commented


**For any changes of the code please consider:**
- [ ] Cover the changes with corresponding unit tests 

For releases only:

- [ ] If the review of this PR is approved and the PR is followed by a release then the .env file
  in the cloud-portal repo should also be updated.
- [ ] If you are making a release then please sum up the changes since the last release on the release page using the [clog](https://github.com/clog-tool/clog-cli) tool with `clog -F`

