### PR TITLE
Feat/cache flavor image

### DIFF
--- a/simple_vm_client/openstack_connector/openstack_connector.py
+++ b/simple_vm_client/openstack_connector/openstack_connector.py
@@ -97,7 +97,16 @@ class OpenStackConnector:
         self.USE_APPLICATION_CREDENTIALS: bool = False
         self.NOVA_MICROVERSION = "2.1"
         self.THREADS = 32
-
+        self._image_cache = {}
+        self._image_cache_lock = threading.Lock()
+        self._flavor_cache = {}
+        self._flavor_cache_lock = threading.Lock()
+        self._network_cache = {}
+        self._network_cache_lock = threading.Lock()
+        self._sg_cache = {}
+        self._sg_cache_lock = threading.Lock()
+        self._limits_cache = {}
+        self._limits_cache_lock = threading.Lock()
         self.load_env_config()
         logger.info(f"Loading config file: {config_file}")
         self.load_config_yml(config_file)
@@ -154,11 +163,6 @@ class OpenStackConnector:
         except Exception as e:
             logger.error("Client failed authentication at Openstack!")
             raise ConnectionError("Client failed authentication at Openstack") from e
-
-        self._image_cache = {}
-        self._image_cache_lock = threading.Lock()
-        self._flavor_cache = {}
-        self._flavor_cache_lock = threading.Lock()
 
         self.DEACTIVATE_UPGRADES_SCRIPT = self.create_deactivate_update_script()
 
@@ -699,9 +703,7 @@ class OpenStackConnector:
     def get_network(self) -> Network:
         logger.debug("Fetching network", extra={"network_name": self.NETWORK})
         try:
-            network: Network = self.openstack_connection.get_network(
-                name_or_id=self.NETWORK
-            )
+            network: Network = self._get_raw_network(name_or_id=self.NETWORK)
             if network is None:
                 logger.error("Network not found", extra={"network_name": self.NETWORK})
                 raise Exception(f"Network {self.NETWORK} not found!")
@@ -1043,6 +1045,88 @@ class OpenStackConnector:
                 name_or_id="unknown",
             )
         return max(images, key=lambda img: img.created_at)
+
+    def _get_raw_network(self, name_or_id: str) -> Network:
+        """Fetch network from OpenStack with caching."""
+        now = time.time()
+        with self._network_cache_lock:
+            if name_or_id in self._network_cache:
+                timestamp, network = self._network_cache[name_or_id]
+                if now - timestamp < self.CACHE_TTL:
+                    logger.debug(f"Cache hit for network {name_or_id}")
+                    return network
+
+        logger.debug(f"Cache miss for network {name_or_id}, fetching from OpenStack")
+        try:
+            network = self.openstack_connection.get_network(name_or_id=name_or_id)
+            if network:
+                with self._network_cache_lock:
+                    self._network_cache[name_or_id] = (now, network)
+                    if network.id != name_or_id:
+                        self._network_cache[network.id] = (now, network)
+            return network
+        except Exception as e:
+            logger.error(f"Error in _get_raw_network for {name_or_id}: {e}")
+            raise
+
+    def _get_raw_security_group(self, name_or_id: str) -> SecurityGroup:
+        """Fetch security group from OpenStack with caching."""
+        now = time.time()
+        with self._sg_cache_lock:
+            if name_or_id in self._sg_cache:
+                timestamp, sg = self._sg_cache[name_or_id]
+                if now - timestamp < self.CACHE_TTL:
+                    logger.debug(f"Cache hit for security group {name_or_id}")
+                    return sg
+
+        logger.debug(
+            f"Cache miss for security group {name_or_id}, fetching from OpenStack"
+        )
+        try:
+            sg = self.openstack_connection.get_security_group(name_or_id=name_or_id)
+            if sg:
+                with self._sg_cache_lock:
+                    self._sg_cache[name_or_id] = (now, sg)
+                    if sg.id != name_or_id:
+                        self._sg_cache[sg.id] = (now, sg)
+            return sg
+        except Exception as e:
+            logger.error(f"Error in _get_raw_security_group for {name_or_id}: {e}")
+            raise
+
+    def _get_raw_limits(self) -> dict[str, str]:
+        """Fetch OpenStack limits with caching."""
+        now = time.time()
+        with self._limits_cache_lock:
+            if "current" in self._limits_cache:
+                timestamp, limits = self._limits_cache["current"]
+                if now - timestamp < self.CACHE_TTL:
+                    logger.debug("Cache hit for limits")
+                    return limits
+
+        logger.debug("Cache miss for limits, fetching from OpenStack")
+        try:
+            compute_limits = self.openstack_connection.get_compute_limits()
+            volume_limits = self.openstack_connection.get_volume_limits()["absolute"]
+            limits = {**compute_limits, **volume_limits}
+            result = {
+                "cores_limit": str(limits["max_total_cores"]),
+                "vms_limit": str(limits["max_total_instances"]),
+                "ram_limit": str(math.ceil(limits["max_total_ram_size"] / 1024)),
+                "current_used_cores": str(limits["total_cores_used"]),
+                "current_used_vms": str(limits["total_instances_used"]),
+                "current_used_ram": str(math.ceil(limits["total_ram_used"] / 1024)),
+                "volume_counter_limit": str(limits["max_total_volumes"]),
+                "volume_storage_limit": str(limits["max_total_volume_gigabytes"]),
+                "current_used_volumes": str(limits["total_volumes_used"]),
+                "current_used_volume_storage": str(limits["total_gigabytes_used"]),
+            }
+            with self._limits_cache_lock:
+                self._limits_cache["current"] = (now, result)
+            return result
+        except Exception as e:
+            logger.error(f"Error in _get_raw_limits: {e}")
+            raise
 
     def _get_raw_image(self, name_or_id: str) -> Image:
         """Fetch image from OpenStack with caching."""
@@ -1464,9 +1548,7 @@ class OpenStackConnector:
             "Checking for default SimpleVM SSH Security Group",
             extra={"security_group": self.DEFAULT_SECURITY_GROUP_NAME},
         )
-        sec = self.openstack_connection.get_security_group(
-            name_or_id=self.DEFAULT_SECURITY_GROUP_NAME
-        )
+        sec = self._get_raw_security_group(name_or_id=self.DEFAULT_SECURITY_GROUP_NAME)
         if not sec:
             logger.info(
                 "Default SimpleVM SSH Security group not found - creating",
@@ -1596,9 +1678,7 @@ class OpenStackConnector:
             "Creating new security group",
             extra={"name_or_id": name, "description": description},
         )
-        sec: SecurityGroup = self.openstack_connection.get_security_group(
-            name_or_id=name
-        )
+        sec: SecurityGroup = self._get_raw_security_group(name_or_id=name)
         if sec:
             logger.debug(
                 "Security group already exists",
@@ -1750,9 +1830,7 @@ class OpenStackConnector:
             "Fetching research environment security group",
             extra={"security_group_name": security_group_name},
         )
-        security_group = self.openstack_connection.get_security_group(
-            name_or_id=security_group_name
-        )
+        security_group = self._get_raw_security_group(name_or_id=security_group_name)
         if not security_group:
             logger.warning(
                 "Research environment security group not found",
@@ -1779,7 +1857,7 @@ class OpenStackConnector:
             "Checking for research environment security group",
             extra={"security_group_name": resenv_metadata.securitygroup_name},
         )
-        sec = self.openstack_connection.get_security_group(
+        sec = self._get_raw_security_group(
             name_or_id=resenv_metadata.securitygroup_name
         )
         if sec:
@@ -1823,9 +1901,7 @@ class OpenStackConnector:
             "Fetching security group ID by name",
             extra={"security_group_name": security_group_name},
         )
-        sec = self.openstack_connection.get_security_group(
-            name_or_id=security_group_name
-        )
+        sec = self._get_raw_security_group(name_or_id=security_group_name)
         if not sec:
             logger.error(
                 "Security group not found",
@@ -1847,7 +1923,7 @@ class OpenStackConnector:
         logger.debug(
             "Checking for VM security group", extra={"server_id": openstack_id}
         )
-        sec = self.openstack_connection.get_security_group(name_or_id=openstack_id)
+        sec = self._get_raw_security_group(name_or_id=openstack_id)
         if sec:
             logger.debug(
                 "VM security group already exists",
@@ -1880,9 +1956,7 @@ class OpenStackConnector:
                 "Checking for project security group",
                 extra={"project_name": project_name, "project_id": project_id},
             )
-            sec = self.openstack_connection.get_security_group(
-                name_or_id=security_group_name
-            )
+            sec = self._get_raw_security_group(name_or_id=security_group_name)
             if sec:
                 logger.debug(
                     "Project security group already exists",
@@ -1920,43 +1994,7 @@ class OpenStackConnector:
             return new_security_group["id"]
 
     def get_limits(self) -> dict[str, str]:
-        logger.debug("Fetching OpenStack limits")
-        try:
-            # Retrieve compute and volume limits
-            compute_limits = self.openstack_connection.get_compute_limits()
-            volume_limits = self.openstack_connection.get_volume_limits()["absolute"]
-
-            # Merge compute and volume limits into a single dictionary
-            limits = {**compute_limits, **volume_limits}
-            result = {
-                "cores_limit": str(limits["max_total_cores"]),
-                "vms_limit": str(limits["max_total_instances"]),
-                "ram_limit": str(math.ceil(limits["max_total_ram_size"] / 1024)),
-                "current_used_cores": str(limits["total_cores_used"]),
-                "current_used_vms": str(limits["total_instances_used"]),
-                "current_used_ram": str(math.ceil(limits["total_ram_used"] / 1024)),
-                "volume_counter_limit": str(limits["max_total_volumes"]),
-                "volume_storage_limit": str(limits["max_total_volume_gigabytes"]),
-                "current_used_volumes": str(limits["total_volumes_used"]),
-                "current_used_volume_storage": str(limits["total_gigabytes_used"]),
-            }
-            logger.debug(
-                "Limits fetched successfully",
-                extra={
-                    "vm_limit": result["vms_limit"],
-                    "vm_used": result["current_used_vms"],
-                    "cores_limit": result["cores_limit"],
-                    "cores_used": result["current_used_cores"],
-                },
-            )
-            return result
-        except Exception as e:
-            logger.error(
-                "Error fetching OpenStack limits",
-                extra={"error": str(e)},
-                exc_info=True,
-            )
-            raise
+        return self._get_raw_limits()
 
     def exist_server(self, name: str) -> bool:
         logger.debug("Checking if server exists", extra={"server_name": name})
@@ -2199,9 +2237,7 @@ class OpenStackConnector:
     def _delete_security_groups_if_not_used(self, security_groups: list[SecurityGroup]):
         if security_groups is not None:
             for sg in security_groups:
-                sec = self.openstack_connection.get_security_group(
-                    name_or_id=sg["name"]
-                )
+                sec = self._get_raw_security_group(name_or_id=sg["name"])
                 if sg[
                     "name"
                 ] != self.DEFAULT_SECURITY_GROUP_NAME and not self.is_security_group_in_use(
@@ -2231,9 +2267,7 @@ class OpenStackConnector:
 
         if security_groups is not None:
             for sg in security_groups:
-                sec = self.openstack_connection.get_security_group(
-                    name_or_id=sg["name"]
-                )
+                sec = self._get_raw_security_group(name_or_id=sg["name"])
                 logger.debug(
                     "Removing security group from server",
                     extra={"server_id": server.id, "security_group_id": sec.id},
@@ -2639,9 +2673,7 @@ class OpenStackConnector:
             )
         if additional_security_group_ids:
             for security_id in additional_security_group_ids:
-                sec = self.openstack_connection.get_security_group(
-                    name_or_id=security_id
-                )
+                sec = self._get_raw_security_group(name_or_id=security_id)
                 if sec:
                     security_groups.append(sec["id"])
         logger.debug(
@@ -2821,9 +2853,7 @@ class OpenStackConnector:
         security_group_id = self.get_or_create_project_security_group(
             project_name=project_name, project_id=project_id
         )
-        security_group = self.openstack_connection.get_security_group(
-            name_or_id=security_group_id
-        )
+        security_group = self._get_raw_security_group(name_or_id=security_group_id)
         if self._is_security_group_already_added_to_server(
             server=server, security_group_name=security_group.name
         ):
@@ -2877,7 +2907,7 @@ class OpenStackConnector:
         logger.debug("Setting up UDP security group", extra={"server_id": server_id})
         server = self.get_server(openstack_id=server_id)
         sec_name = server.name + "_udp"
-        existing_sec = self.openstack_connection.get_security_group(name_or_id=sec_name)
+        existing_sec = self._get_raw_security_group(name_or_id=sec_name)
         if existing_sec:
             logger.debug(
                 "UDP Security group already exists", extra={"security_group": sec_name}

--- a/simple_vm_client/openstack_connector/openstack_connector.py
+++ b/simple_vm_client/openstack_connector/openstack_connector.py
@@ -1141,7 +1141,7 @@ class OpenStackConnector:
         logger.debug(f"Cache miss for image {name_or_id}, fetching from OpenStack")
         try:
             image = self.openstack_connection.get_image(name_or_id=name_or_id)
-            if image:
+            if image and image.status == "active":
                 with self._image_cache_lock:
                     self._image_cache[name_or_id] = (now, image)
                     if image.id != name_or_id:

--- a/simple_vm_client/openstack_connector/openstack_connector.py
+++ b/simple_vm_client/openstack_connector/openstack_connector.py
@@ -5,6 +5,7 @@ import os
 import socket
 import sys
 import threading
+import time
 import urllib
 import urllib.parse
 from contextlib import closing
@@ -65,6 +66,8 @@ lock_access = threading.Lock()
 
 
 class OpenStackConnector:
+    CACHE_TTL = 600
+
     def __init__(self, config_file: str):
         # Config FIle Data
         logger.info(
@@ -151,6 +154,11 @@ class OpenStackConnector:
         except Exception as e:
             logger.error("Client failed authentication at Openstack!")
             raise ConnectionError("Client failed authentication at Openstack") from e
+
+        self._image_cache = {}
+        self._image_cache_lock = threading.Lock()
+        self._flavor_cache = {}
+        self._flavor_cache_lock = threading.Lock()
 
         self.DEACTIVATE_UPGRADES_SCRIPT = self.create_deactivate_update_script()
 
@@ -506,9 +514,7 @@ class OpenStackConnector:
                 flavor = server.flavor
                 if flavor and not flavor.get("name"):
                     if not flavors.get(flavor.id):
-                        openstack_flavor = self.openstack_connection.get_flavor(
-                            flavor.id
-                        )
+                        openstack_flavor = self._get_raw_flavor(flavor.id)
                         flavors[flavor.id] = openstack_flavor
                         server.flavor = openstack_flavor
                     else:
@@ -517,7 +523,7 @@ class OpenStackConnector:
                 image = server.image
                 if image and not image.get("name"):
                     if not images.get(image.id):
-                        openstack_image = self.openstack_connection.get_image(image.id)
+                        openstack_image = self._get_raw_image(image.id)
                         images[image.id] = openstack_image
                         server.image = openstack_image
                     else:
@@ -555,7 +561,7 @@ class OpenStackConnector:
             flavor = server.flavor
             if flavor and not flavor.get("name"):
                 if not flavors.get(flavor.id):
-                    openstack_flavor = self.openstack_connection.get_flavor(flavor.id)
+                    openstack_flavor = self._get_raw_flavor(flavor.id)
                     flavors[flavor.id] = openstack_flavor
                     server.flavor = openstack_flavor
                 else:
@@ -564,7 +570,7 @@ class OpenStackConnector:
             image = server.image
             if image and not image.get("name"):
                 if not image.get(image.id):
-                    openstack_image = self.openstack_connection.get_image(image.id)
+                    openstack_image = self._get_raw_image(image.id)
                     images[image.id] = openstack_image
                     server.image = openstack_image
                 else:
@@ -840,9 +846,7 @@ class OpenStackConnector:
     def get_flavor(self, name_or_id: str, ignore_error: bool = False) -> Flavor:
         logger.debug("Fetching flavor", extra={"name_or_id": name_or_id})
         try:
-            flavor: Flavor = self.openstack_connection.get_flavor(
-                name_or_id=name_or_id, get_extra=True
-            )
+            flavor: Flavor = self._get_raw_flavor(name_or_id)
 
             if flavor is None:
                 logger.warning("Flavor not found", extra={"name_or_id": name_or_id})
@@ -904,9 +908,7 @@ class OpenStackConnector:
                 flavor = server.flavor
                 if not flavor.get("name"):
                     if not flavors.get(flavor.id):
-                        openstack_flavor = self.openstack_connection.get_flavor(
-                            flavor.id
-                        )
+                        openstack_flavor = self._get_raw_flavor(flavor.id)
                         flavors[flavor.id] = openstack_flavor
                         server.flavor = openstack_flavor
                     else:
@@ -915,7 +917,7 @@ class OpenStackConnector:
                 image = server.image
                 if not image.get("name"):
                     if not images.get(image.id):
-                        openstack_image = self.openstack_connection.get_image(image.id)
+                        openstack_image = self._get_raw_image(image.id)
                         images[image.id] = openstack_image
                         server.image = openstack_image
                     else:
@@ -1042,6 +1044,54 @@ class OpenStackConnector:
             )
         return max(images, key=lambda img: img.created_at)
 
+    def _get_raw_image(self, name_or_id: str) -> Image:
+        """Fetch image from OpenStack with caching."""
+        now = time.time()
+        with self._image_cache_lock:
+            if name_or_id in self._image_cache:
+                timestamp, image = self._image_cache[name_or_id]
+                if now - timestamp < self.CACHE_TTL:
+                    logger.debug(f"Cache hit for image {name_or_id}")
+                    return image
+
+        logger.debug(f"Cache miss for image {name_or_id}, fetching from OpenStack")
+        try:
+            image = self.openstack_connection.get_image(name_or_id=name_or_id)
+            if image:
+                with self._image_cache_lock:
+                    self._image_cache[name_or_id] = (now, image)
+                    if image.id != name_or_id:
+                        self._image_cache[image.id] = (now, image)
+            return image
+        except Exception as e:
+            logger.error(f"Error in _get_raw_image for {name_or_id}: {e}")
+            raise
+
+    def _get_raw_flavor(self, name_or_id: str) -> Flavor:
+        """Fetch flavor from OpenStack with caching."""
+        now = time.time()
+        with self._flavor_cache_lock:
+            if name_or_id in self._flavor_cache:
+                timestamp, flavor = self._flavor_cache[name_or_id]
+                if now - timestamp < self.CACHE_TTL:
+                    logger.debug(f"Cache hit for flavor {name_or_id}")
+                    return flavor
+
+        logger.debug(f"Cache miss for flavor {name_or_id}, fetching from OpenStack")
+        try:
+            flavor = self.openstack_connection.get_flavor(
+                name_or_id=name_or_id, get_extra=True
+            )
+            if flavor:
+                with self._flavor_cache_lock:
+                    self._flavor_cache[name_or_id] = (now, flavor)
+                    if flavor.id != name_or_id:
+                        self._flavor_cache[flavor.id] = (now, flavor)
+            return flavor
+        except Exception as e:
+            logger.error(f"Error in _get_raw_flavor for {name_or_id}: {e}")
+            raise
+
     def get_image(
         self,
         name_or_id: str,
@@ -1056,10 +1106,10 @@ class OpenStackConnector:
             extra={"name_or_id": name_or_id, "slurm_version": slurm_version},
         )
 
-        logger.info(f"Get Image {name_or_id}")
+        logger.debug(f"Get Image {name_or_id}")
 
         try:
-            image = self.openstack_connection.get_image(name_or_id=name_or_id)
+            image = self._get_raw_image(name_or_id=name_or_id)
         except DuplicateResource:
             logger.warning(
                 f"Multiple images found with name '{name_or_id}'. "

--- a/simple_vm_client/openstack_connector/test_openstack_connector.py
+++ b/simple_vm_client/openstack_connector/test_openstack_connector.py
@@ -404,6 +404,23 @@ class TestOpenStackConnector(unittest.TestCase):
         # SDK should only be called once
         self.mock_openstack_connection.get_image.assert_called_once()
 
+    def test_get_image_inactive_not_cached(self):
+        self.mock_openstack_connection.get_image.return_value = INACTIVE_IMAGE
+
+        # First call - cache miss
+        result1 = self.openstack_connector.get_image(
+            INACTIVE_IMAGE.id, ignore_not_active=True
+        )
+        # Second call - should still be a cache miss
+        result2 = self.openstack_connector.get_image(
+            INACTIVE_IMAGE.id, ignore_not_active=True
+        )
+
+        self.assertEqual(result1, INACTIVE_IMAGE)
+        self.assertEqual(result2, INACTIVE_IMAGE)
+        # SDK should be called twice because it's not cached
+        self.assertEqual(self.mock_openstack_connection.get_image.call_count, 2)
+
     def test_get_network_caching(self):
         fake_network = fakes.generate_fake_resource(Network)
         self.mock_openstack_connection.get_network.return_value = fake_network

--- a/simple_vm_client/openstack_connector/test_openstack_connector.py
+++ b/simple_vm_client/openstack_connector/test_openstack_connector.py
@@ -184,6 +184,18 @@ class TestOpenStackConnector(unittest.TestCase):
                 "dedasdasdasdadew1231231"
             )
             self.openstack_connector.NOVA_MICROVERSION = "2.1"
+            # Initialize caches since __init__ is patched
+            self.openstack_connector._image_cache = {}
+            self.openstack_connector._image_cache_lock = mock.MagicMock()
+            self.openstack_connector._flavor_cache = {}
+            self.openstack_connector._flavor_cache_lock = mock.MagicMock()
+            self.openstack_connector._network_cache = {}
+            self.openstack_connector._network_cache_lock = mock.MagicMock()
+            self.openstack_connector._sg_cache = {}
+            self.openstack_connector._sg_cache_lock = mock.MagicMock()
+            self.openstack_connector._limits_cache = {}
+            self.openstack_connector._limits_cache_lock = mock.MagicMock()
+
             with tempfile.NamedTemporaryFile(mode="w+", delete=False) as temp_file:
                 temp_file.write(CONFIG_DATA)
 
@@ -378,6 +390,72 @@ class TestOpenStackConnector(unittest.TestCase):
             extra={"name_or_id": EXPECTED_IMAGE.id, "slurm_version": None},
         )
         self.assertEqual(result, EXPECTED_IMAGE)
+
+    def test_get_image_caching(self):
+        self.mock_openstack_connection.get_image.return_value = EXPECTED_IMAGE
+
+        # First call - cache miss
+        result1 = self.openstack_connector.get_image(EXPECTED_IMAGE.id)
+        # Second call - cache hit
+        result2 = self.openstack_connector.get_image(EXPECTED_IMAGE.id)
+
+        self.assertEqual(result1, EXPECTED_IMAGE)
+        self.assertEqual(result2, EXPECTED_IMAGE)
+        # SDK should only be called once
+        self.mock_openstack_connection.get_image.assert_called_once()
+
+    def test_get_network_caching(self):
+        fake_network = fakes.generate_fake_resource(Network)
+        self.mock_openstack_connection.get_network.return_value = fake_network
+
+        # First call - cache miss
+        result1 = self.openstack_connector.get_network()
+        # Second call - cache hit
+        result2 = self.openstack_connector.get_network()
+
+        self.assertEqual(result1, fake_network)
+        self.assertEqual(result2, fake_network)
+        self.mock_openstack_connection.get_network.assert_called_once()
+
+    def test_get_security_group_caching(self):
+        fake_sg = fakes.generate_fake_resource(security_group.SecurityGroup)
+        self.mock_openstack_connection.get_security_group.return_value = fake_sg
+
+        # First call - cache miss
+        result1 = self.openstack_connector._get_raw_security_group(fake_sg.id)
+        # Second call - cache hit
+        result2 = self.openstack_connector._get_raw_security_group(fake_sg.id)
+
+        self.assertEqual(result1, fake_sg)
+        self.assertEqual(result2, fake_sg)
+        self.mock_openstack_connection.get_security_group.assert_called_once()
+
+    def test_get_limits_caching(self):
+        self.mock_openstack_connection.get_compute_limits.return_value = {
+            "max_total_cores": 10,
+            "max_total_instances": 5,
+            "max_total_ram_size": 2048,
+            "total_cores_used": 2,
+            "total_instances_used": 1,
+            "total_ram_used": 512,
+        }
+        self.mock_openstack_connection.get_volume_limits.return_value = {
+            "absolute": {
+                "max_total_volumes": 100,
+                "max_total_volume_gigabytes": 1000,
+                "total_volumes_used": 10,
+                "total_gigabytes_used": 100,
+            }
+        }
+
+        # First call - cache miss
+        result1 = self.openstack_connector.get_limits()
+        # Second call - cache hit
+        result2 = self.openstack_connector.get_limits()
+
+        self.assertEqual(result1, result2)
+        self.mock_openstack_connection.get_compute_limits.assert_called_once()
+        self.mock_openstack_connection.get_volume_limits.assert_called_once()
 
     @patch("simple_vm_client.openstack_connector.openstack_connector.logger.debug")
     def test_get_image_not_found_exception(self, mock_logger_debug):
@@ -1425,6 +1503,20 @@ class TestOpenStackConnector(unittest.TestCase):
             name_or_id=expected_flavor.name, get_extra=True
         )
 
+    def test_get_flavor_caching(self):
+        expected_flavor = fakes.generate_fake_resource(flavor.Flavor)
+        self.mock_openstack_connection.get_flavor.return_value = expected_flavor
+
+        # First call - cache miss
+        result1 = self.openstack_connector.get_flavor(expected_flavor.name)
+        # Second call - cache hit
+        result2 = self.openstack_connector.get_flavor(expected_flavor.name)
+
+        self.assertEqual(result1, expected_flavor)
+        self.assertEqual(result2, expected_flavor)
+        # SDK should only be called once
+        self.mock_openstack_connection.get_flavor.assert_called_once()
+
     @mock.patch("simple_vm_client.openstack_connector.openstack_connector.logger.debug")
     def test_get_flavors(self, mock_logger_debug):
         # Replace with the actual flavors you want to simulate
@@ -1566,7 +1658,7 @@ class TestOpenStackConnector(unittest.TestCase):
         with self.assertRaises(DefaultException):
             self.openstack_connector.delete_image(fake_image.id)
         mock_logger_error.assert_called_once_with(
-            f"Failed to delete image",
+            "Failed to delete image",
             extra={"image_id": fake_image.id, "error": mock.ANY},
             exc_info=True,
         )


### PR DESCRIPTION
@vktrrdk 

Added some caching for more stale informations which are requested often:

get_flavor -> by_id
get_network 
get_image -> by id
get_security_group 

The information are cached for 10 Minutes, if cache missed actual data is requested again.

This should boost performance a bit and removed duplicated openstack api request for stale information

Try to fulfill the following points before the Pull Request is merged:

- [ ] Give a meaningfull description for the PR
- [ ] The PR is reviewed by one of the team members.
- [ ] If a linting PR exists, it must be merged before this PR is allowed to be merged.
- [ ] It must be checked if anything in the Readme must be adjusted (development-, production-, setup).
- [ ] If the requirements.txt have changed, check if the patches still work
- [ ] It must be checked if any section in the wiki (https://simplevm.denbi.de/wiki/) should be adjusted.
- [ ] If the PR is merged in the master then a release should be be made.
- [ ] If the new code is readable, if not it should be well commented


**For any changes of the code please consider:**
- [ ] Cover the changes with corresponding unit tests 

For releases only:

- [ ] If the review of this PR is approved and the PR is followed by a release then the .env file
  in the cloud-portal repo should also be updated.
- [ ] If you are making a release then please sum up the changes since the last release on the release page using the [clog](https://github.com/clog-tool/clog-cli) tool with `clog -F`

